### PR TITLE
Add a new optional variable to override cluster name in Service Account `account_id`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -59,7 +59,7 @@
 ### GCP Service Account
 ###--------------------------------
 resource "google_service_account" "self" {
-  account_id   = "${var.gcpsm_secret_prefix}${var.cluster_name}-${var.namespace}"
+  account_id   = "${var.gcpsm_secret_prefix}${coalesce(var.service_account_cluster_prefix, var.cluster_name)}-${var.namespace}"
   description  = "Permissions for ESO to access secrets for ${var.namespace}"
   display_name = "ESO Secret Access for ${var.namespace}"
   project      = var.project_id

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,3 @@
-
 variable "cluster_location" {
   description = "GKE cluster location"
   type        = string
@@ -64,4 +63,9 @@ variable "shared_secrets" {
   description = "Shared secrets list"
   type        = list(string)
   default     = []
+}
+variable "service_account_cluster_prefix" {
+  description = "Optional shorter prefix to use for the service account ID instead of the full cluster name"
+  type        = string
+  default     = null
 }


### PR DESCRIPTION
The Service Account `account_id` has a character limit of 30 set by Google. Currently, we concatenate the cluster name and the namespace name to generate the SA id, which can easily exceed this limit. This approach allows the client to override the cluster name part with a shorter name. The user can override the cluster name for a shorter name that can still identify the cluster uniquely. 

Alternative considered: Some sort of truncation. But this can become tricky to ensure that the names are unique, eg. `test-cluster-1` and `test-cluster-2` could both get truncated to `test-cluster`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional setting to customize the prefix used in service account IDs, allowing for shorter or alternative prefixes.
- **Chores**
  - Updated configuration to support the new optional prefix without affecting existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->